### PR TITLE
stop execution and display help on invalid parameters

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -38,7 +38,8 @@ do
 			fi
 			;;
 		*)
-			shift
+			echo "Unknown parameter '$1'"
+			exec $0 --help
 			;;
 	esac
 done


### PR DESCRIPTION
can show typo error in parameters or wrong usage:

```
curl -sSL https://raw.githubusercontent.com/ezweb/git-up/master/bin/setup | sh -s -- --install-dir=~/.git-up
curl -sSL https://raw.githubusercontent.com/ezweb/git-up/master/bin/setup | sh -s -- --installdir ~/.git-up
```
