### PR TITLE
fetch PR from Github repository

### DIFF
--- a/adc/up
+++ b/adc/up
@@ -261,7 +261,7 @@ setup_provision() {
 provision() {
 	debug "git fetch"
 	git fetch --tags $( test $debug -eq 0 && echo -q ) origin
-	git fetch $( test $debug -eq 0 && echo -q ) origin
+	git fetch $( test $debug -eq 0 && echo -q ) origin --refmap="+refs/pull/*/head:refs/remotes/origin/pr/*"
 	debug "git fetch done."
 }
 


### PR DESCRIPTION
closes #8

par contre je sais pas comment le tester, en théorie, ceci devrai fonctionner pour mettre en preprod la Pull Request #274 d'un projet hébergé sur GitHub:

``` sh
git up preprod origin/pr/274
```
