### PR TITLE
fix deploying conflicting branches

### DIFF
--- a/adc/up
+++ b/adc/up
@@ -267,6 +267,7 @@ setup_provision() {
 
 provision() {
 	debug "git fetch"
+	git remote prune origin
 	git fetch    $( test $debug -eq 0 && echo -q ) origin --tags                                      # fetch tags
 	git fetch    $( test $debug -eq 0 && echo -q ) origin                                             # fetch branches
 	git fetch -f $( test $debug -eq 0 && echo -q ) origin "refs/pull/*/head:refs/remotes/origin/pr/*" # fetch Pull-Requests


### PR DESCRIPTION
remove old branches before fetch new ones

exemple du bug:

> ~/biz $ git up preprod origin/debug/challenge
> deploying origin/debug/challenge on biz:preprod
> error: unable to resolve reference refs/remotes/origin/debug/challenge: Not a directory
> error: some local refs could not be updated; try running
> 'git remote prune origin' to remove any old, conflicting branches
